### PR TITLE
feat:add pure color props type , change options [image] => [cover]

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,10 @@
     "es2015"
   ],
   "plugins": [
+    "transform-decorators-legacy",      
+    "transform-object-rest-spread",   
+    "transform-class-properties",    
+    "transform-runtime",
     "react-hot-loader/babel"
   ]
 }

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -7,7 +7,7 @@ import cardImage from './card.jpg';
 const settings = {
   width: 640,
   height: 480,
-  image: cardImage,
+  cover: "#396",
   finishPercent: 50,
   onComplete: () => console.log('The card is now clear!')
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React component for displaying scratch card in your web app.",
   "main": "dist/index.js",
   "scripts": {
+    "start": "npm run start-example",
     "build": "babel src -d dist",
     "start-example": "webpack-dev-server --progress --profile --colors",
     "build-example": "webpack --config webpack.production.config.js --progress --profile --colors"
@@ -19,6 +20,7 @@
     "url": "https://github.com/aleksik/react-scratchcard.git"
   },
   "dependencies": {
+    "classnames": "^2.2.5",
     "react": "^15.0.0"
   },
   "devDependencies": {
@@ -27,6 +29,8 @@
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-class-properties": "^6.16.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
@@ -34,12 +38,12 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
+    "react-dom": "^15.0.0",
     "react-hot-loader": "^3.0.0-beta.5",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-cleanup-plugin": "^0.4.0",
-    "webpack-dev-server": "^1.16.1",
-    "react-dom": "^15.0.0"
+    "webpack-dev-server": "^1.16.1"
   }
 }


### PR DESCRIPTION
### Hello :)
#### your code `options` only  `drawImage` accept a `image` props option 
#### i change the `image` props to `cover`   It turns it into two different types of parameters
#### Not only `image` cover String,  Can also be use `hexadecimal coding`  or `rgba()` 
> like `#396` or `rgba(255,255,255,.3)`
#### please see `index.js`
```js
  componentDidMount() {
    const { cover } = this.props
    this.isDrawing = false;
    this.lastPoint = null;
    this.ctx = this.canvas.getContext('2d');

    const isColorCover = this.checkColorCover(cover)

    if (!isColorCover) {
      const image = new Image();
      image.crossOrigin = "Anonymous";
      image.onload = () => {
        this.ctx.drawImage(image, 0, 0);
        this.setState({ loaded: true });
      }
      image.src = cover;
    } else {
      const { width, height } = this.canvas
      this.ctx.save()
      this.ctx.fillStyle = cover
      this.ctx.beginPath()
      this.ctx.rect(0, 0, width, height)
      this.ctx.fill()
      this.ctx.restore()
      this.setState({ loaded: true });
    }

  }
  checkColorCover(cover) {
    return (/^#(\d|\w){3,6}$/.test(cover) || /^rgba?\(.*\)/.test(cover))
  }
```

####  And I made a little bit of improvement
#### i add a new package `classnames` in your code
#### This allows the user to expand his own  like `className` , `style`
```js
    return (
      <div
        className={classnames("ScratchCard__Container", className)}
        style={containerStyle}
        {...attr}
      >
        <canvas {...canvasProps}></canvas>
        <div className="ScratchCard__Result" style={resultStyle}>
          {this.props.children}
        </div>
      </div>
    );
```



